### PR TITLE
note component /song parser fix

### DIFF
--- a/Assets/prefabs/KiruPlayer.prefab
+++ b/Assets/prefabs/KiruPlayer.prefab
@@ -3,11 +3,18 @@
     "__guid": "9940c5d5-9261-4aad-b4f8-b7effdc23e9c",
     "Flags": 0,
     "Name": "kiruplayer",
+    "Tags": "player",
     "Enabled": true,
     "Components": [
       {
         "__type": "Sandbox.VR.VRAnchor",
-        "__guid": "76c8fe74-3183-426d-93a7-d0ea44c05c69"
+        "__guid": "76c8fe74-3183-426d-93a7-d0ea44c05c69",
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null
       }
     ],
     "Children": [
@@ -20,6 +27,13 @@
           {
             "__type": "Sandbox.VR.VRTrackedObject",
             "__guid": "ea291ab5-0701-4f6b-b41c-de1edc0959b4",
+            "__enabled": false,
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
             "PoseSource": "Head",
             "TrackingType": "All",
             "UseRelativeTransform": false
@@ -40,6 +54,12 @@
                 "ClearFlags": "All",
                 "FieldOfView": 60,
                 "IsMainCamera": true,
+                "OnComponentDestroy": null,
+                "OnComponentDisabled": null,
+                "OnComponentEnabled": null,
+                "OnComponentFixedUpdate": null,
+                "OnComponentStart": null,
+                "OnComponentUpdate": null,
                 "Orthographic": false,
                 "OrthographicHeight": 1204,
                 "Priority": 1,
@@ -63,6 +83,12 @@
           {
             "__type": "Sandbox.VR.VRTrackedObject",
             "__guid": "68477287-098e-4039-8c4b-0ce118349dd9",
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
             "PoseSource": "LeftHand",
             "TrackingType": "All",
             "UseRelativeTransform": false
@@ -91,6 +117,12 @@
           {
             "__type": "Sandbox.VR.VRTrackedObject",
             "__guid": "47571871-c055-4eb6-97c7-26ccece7f1e8",
+            "OnComponentDestroy": null,
+            "OnComponentDisabled": null,
+            "OnComponentEnabled": null,
+            "OnComponentFixedUpdate": null,
+            "OnComponentStart": null,
+            "OnComponentUpdate": null,
             "PoseSource": "RightHand",
             "TrackingType": "All",
             "UseRelativeTransform": false
@@ -119,7 +151,13 @@
                 "__type": "Sandbox.KiruVRWorldInput",
                 "__guid": "da640d2f-ec9c-4249-b1e1-9154df5a16b5",
                 "DampingFactor": 0,
-                "HandSource": "Right"
+                "HandSource": "Right",
+                "OnComponentDestroy": null,
+                "OnComponentDisabled": null,
+                "OnComponentEnabled": null,
+                "OnComponentFixedUpdate": null,
+                "OnComponentStart": null,
+                "OnComponentUpdate": null
               }
             ]
           }

--- a/Assets/prefabs/note.prefab
+++ b/Assets/prefabs/note.prefab
@@ -5,6 +5,24 @@
     "Name": "note",
     "Tags": "note",
     "Enabled": true,
+    "Components": [
+      {
+        "__type": "Kiru.NoteComponent",
+        "__guid": "a47eec77-5ddf-4e2e-96dc-7ed1147000ef",
+        "Model": {
+          "_type": "component",
+          "component_id": "ea391dc1-cc00-4658-b223-127f36895197",
+          "go": "18743f20-4864-44ff-a49f-fdc032242af2",
+          "component_type": "ModelRenderer"
+        },
+        "OnComponentDestroy": null,
+        "OnComponentDisabled": null,
+        "OnComponentEnabled": null,
+        "OnComponentFixedUpdate": null,
+        "OnComponentStart": null,
+        "OnComponentUpdate": null
+      }
+    ],
     "Children": [
       {
         "__guid": "005fc3f6-2c2d-4776-bf1c-4a7f3d15f07b",
@@ -259,27 +277,12 @@
         "Enabled": true,
         "Components": [
           {
-            "__type": "Kiru.NoteComponent",
-            "__guid": "51432f03-1e1d-4bfd-934b-10f7fa1ed281",
-            "Model": {
-              "_type": "component",
-              "component_id": "ea391dc1-cc00-4658-b223-127f36895197",
-              "go": "18743f20-4864-44ff-a49f-fdc032242af2",
-              "component_type": "ModelRenderer"
-            },
-            "OnComponentDestroy": null,
-            "OnComponentDisabled": null,
-            "OnComponentEnabled": null,
-            "OnComponentFixedUpdate": null,
-            "OnComponentStart": null,
-            "OnComponentUpdate": null
-          },
-          {
             "__type": "Sandbox.BoxCollider",
             "__guid": "87995cae-ba77-4129-9512-0e3bc7fe57d6",
+            "__enabled": false,
             "Center": "0,0,0",
             "Friction": null,
-            "IsTrigger": false,
+            "IsTrigger": true,
             "OnComponentDestroy": null,
             "OnComponentDisabled": null,
             "OnComponentEnabled": null,

--- a/code/NoteComponent.cs
+++ b/code/NoteComponent.cs
@@ -11,8 +11,12 @@ public sealed class NoteComponent : Component
 	public float NoteSpeed { get; set; } = 300f;
 	protected override void OnStart()
 	{
+		if ( Model == null ){ Log.Error( $"Model is null in NoteComponent." ); return; }
+		if ( noteData == null ){ Log.Error( "noteData is null in NoteComponent." ); return; }
+		if ( Parser == null ){ Log.Error( "Parser is null in NoteComponent." ); return; }
+
 		// Apply note color
-		Log.Info(Model);
+		Log.Info( $"Model Tint: {Model.Tint}" );
 		//Model.Tint = noteData.Type.Equals( 0 ) ? Parser.LeftNoteColor : Parser.RightNoteColor;
 		// // Apply note rotation
 		// if ( noteData.CutDirection != 8 )

--- a/code/NoteComponent.cs
+++ b/code/NoteComponent.cs
@@ -16,15 +16,14 @@ public sealed class NoteComponent : Component
 		if ( Parser == null ){ Log.Error( "Parser is null in NoteComponent." ); return; }
 
 		// Apply note color
-		Log.Info( $"Model Tint: {Model.Tint}" );
-		//Model.Tint = noteData.Type.Equals( 0 ) ? Parser.LeftNoteColor : Parser.RightNoteColor;
-		// // Apply note rotation
-		// if ( noteData.CutDirection != 8 )
-		// {
-		// 	Angle = ToRotation( noteData.CutDirection );
-		// }
-		// else Angle = 0;
-		// LocalRotation = new Angles( 0, 0, Angle );
+		Model.Tint = noteData.Type.Equals( 0 ) ? Parser.LeftNoteColor : Parser.RightNoteColor;
+		// Apply note rotation
+		if ( noteData.CutDirection != 8 )
+		{
+			Angle = ToRotation( noteData.CutDirection );
+		}
+		else Angle = 0;
+		LocalRotation = new Angles( 0, 0, Angle );
 	}
 	protected override void OnFixedUpdate()
 	{

--- a/code/SongParser.cs
+++ b/code/SongParser.cs
@@ -43,7 +43,8 @@ public sealed class SongParser : Component
 			{
 				//Spawn note prefab, set position, and pass note data
 				GameObject no = NotePrefab.Clone( grid.Positions[currentNote.LineIndex][currentNote.LineLayer].WorldPosition );
-				NoteComponent co = no.Components.GetOrCreate<NoteComponent>();
+				no.Name = $"note_{noteCount.ToString()}";
+				NoteComponent co = no.GetComponentInChildren<NoteComponent>();
 				co.Parser = this;
 				co.noteData = currentNote;
 				co.NoteSpeed = ScrollSpeed;


### PR DESCRIPTION
#Note.prefab
* Moved Kiru.NoteComponent to top of the prefab, for some reason when it's on a child game object and it's only other component on the object is a collider, it doesn't include the game object when the prefab is cloned.

#NoteComponent.cs
+ Null checks for property/variables

#SongParser.cs
+ Added Name to the no prefab when it's cloned.
* changed from Component.GetOrCreate => GetcomponentInChildren. (component already exists so we don't need to create it, just get it from the prefab)